### PR TITLE
Changed visibility of mask transparency

### DIFF
--- a/dioptas/controller/integration/ImageController.py
+++ b/dioptas/controller/integration/ImageController.py
@@ -354,7 +354,7 @@ class ImageController(object):
 
     def change_mask_mode(self):
         self.model.use_mask = self.widget.integration_image_widget.mask_btn.isChecked()
-        self.widget.mask_transparent_cb.setVisible(not self.widget.mask_transparent_cb.isVisible())
+        self.widget.mask_transparent_cb.setVisible(self.model.use_mask)
         self.plot_mask()
         self.model.img_model.img_changed.emit()
 


### PR DESCRIPTION
Mask transparency depended on its previous visibility settings. For some reason this occasionally resulted in the transparency setting appearing only when the Mask button is unchecked.
Now the visibility of Mask transparency depends on Mask button isChecked.
